### PR TITLE
Make yaml-rust non-optional

### DIFF
--- a/pub-sub-service/Cargo.toml
+++ b/pub-sub-service/Cargo.toml
@@ -25,9 +25,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = [ "v4", "fast-rng", "macro-diagnostics"] }
-yaml-rust = { workspace = true, optional = true }
+yaml-rust = { workspace = true }
 
 [features]
-default = ["yaml"]
-yaml = ["yaml-rust"]
 containerize = []

--- a/pub-sub-service/src/load_config.rs
+++ b/pub-sub-service/src/load_config.rs
@@ -4,8 +4,6 @@
 
 //! Loads configuration from external files.
 
-#![cfg(feature = "yaml")]
-
 use std::env;
 
 use config::{Config, File, FileFormat};

--- a/samples/common/Cargo.toml
+++ b/samples/common/Cargo.toml
@@ -23,8 +23,4 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true }
-yaml-rust = { workspace = true, optional = true }
-
-[features]
-default = ["yaml"]
-yaml = ["yaml-rust"]
+yaml-rust = { workspace = true }

--- a/samples/common/src/load_config.rs
+++ b/samples/common/src/load_config.rs
@@ -4,8 +4,6 @@
 
 //! Loads configuration from external files.
 
-#![cfg(feature = "yaml")]
-
 use config::{Config, File, FileFormat};
 use log::error;
 use serde_derive::{Deserialize, Serialize};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
yaml-rust crate is required for service to function. It should not be an optional feature.

## Description
<!--- Describe your changes in detail -->
Made yaml-rust non-optional and removed default feature.
<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>Make yaml-rust non-optional</description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
