### PR TITLE
Fully qualify docker image registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # Create a stage for building the application.
 
 ARG RUST_VERSION=1.72.1
-FROM rust:${RUST_VERSION}-slim-bullseye AS build
+FROM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
 ARG APP_NAME=pub-sub-service
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cp ./target/release/"${APP_NAME}" /app/service
 # most recent version of that tag when you build your Dockerfile. If
 # reproducability is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
-FROM debian:bullseye-slim AS final
+FROM docker.io/library/debian:bullseye-slim AS final
 
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user

--- a/README.md
+++ b/README.md
@@ -351,15 +351,6 @@ root directory:
     podman ps -f ancestor=localhost/pub_sub_service:latest --format="{{.Names}}" | xargs podman stop
     ```
 
-#### Notes
-
-1. By default, podman does not recognize docker images for dockerfile. To fix this, one can add the
-`docker.io` registry to `/etc/containers/registries.conf` by changing the following field:
-
-    ```conf
-    unqualified-search-registries = ["docker.io"]
-    ```
-
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows a user building the Dockerfile in podman to build without needing to first add docker.io to podman's list of unqualified search registries.

## Description
<!--- Describe your changes in detail -->
Dockerfile images are now fully qualified as 'docker.io/library/{image}', ensuring the dockerfile can be built without any other podman setup.
<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>[optional scope]: </description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
