### PR TITLE
Update Dockerfile to allow for config overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,14 @@ RUN adduser \
     --no-create-home \
     --uid "${UID}" \
     appuser
+
+# Create and add user ownership to config directory.
+RUN mkdir -p /sdv/.agemo/config
+RUN chown appuser /sdv/.agemo/config
+
+# Create mnt directory to copy override configs into.
+RUN mkdir -p /mnt/config
+
 USER appuser
 
 WORKDIR /sdv
@@ -71,11 +79,14 @@ ENV AGEMO_HOME=/sdv/.agemo
 # Copy the executable from the "build" stage.
 COPY --from=build /sdv/service /sdv/
 
-# Conditionally copy override config if present.
-COPY --from=build /sdv/*.agemo/config/ /sdv/.agemo/config/
+# Copy startup script. 
+COPY --from=build /sdv/container_startup.sh /sdv/container_startup.sh
+
+# Copy default configs.
+COPY --from=build /sdv/.agemo/config/ /sdv/.agemo/config/
 
 # Expose the port that the application listens on.
 EXPOSE 50051
 
 # What the container should run when it is started.
-CMD ["/sdv/service"]
+CMD ["/sdv/container_startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ ENV AGEMO_HOME=/sdv/.agemo
 # Copy the executable from the "build" stage.
 COPY --from=build /sdv/service /sdv/
 
-# Copy startup script. 
+# Copy startup script.
 COPY --from=build /sdv/container_startup.sh /sdv/container_startup.sh
 
 # Copy default configs.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ environment variable called CONFIG_HOME to the path to the config file:
 1. Then run the container with the following command:
 
     ```shell
-    docker -v ${CONFIG_HOME}:/mnt/config run --name pub_sub_service -p 50051:50051 --env-file=docker.env --add-host=host.docker.internal:host-gateway -it --rm pub_sub_service
+    docker run -v ${CONFIG_HOME}:/mnt/config --name pub_sub_service -p 50051:50051 --env-file=docker.env --add-host=host.docker.internal:host-gateway -it --rm pub_sub_service
     ```
 
 ### Podman

--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ command in the project root directory:
 
 Follow the steps in [Running in Docker](#running-in-docker) to build the container.
 
-1. To run the container with overrided configuration, create your config files and set the path to
-the files to an environment variable called CONFIG_HOME:
+1. To run the container with overrided configuration, create your config file and set an
+environment variable called CONFIG_HOME to the path to the config file:
 
     ```shell
     export CONFIG_HOME={path to directory containing config file}
@@ -300,6 +300,23 @@ root directory:
 
     ```shell
     podman ps -f ancestor=localhost/pub_sub_service:latest --format="{{.Names}}" | xargs podman stop
+    ```
+
+#### Running in Podman with overrided configuration
+
+Follow the steps in [Running in Podman](#running-in-podman) to build the container.
+
+1. To run the container with overrided configuration, create your config file and set an
+environment variable called CONFIG_HOME to the path to the config file:
+
+    ```shell
+    export CONFIG_HOME={path to directory containing config file}
+    ```
+
+1. Then run the container with the following command:
+
+    ```shell
+    podman run --mount=type=bind,src=${CONFIG_HOME},dst=/mnt/config,ro=true -p 50051:50051 --env-file=podman.env --network=slirp4netns:allow_host_loopback=true localhost/pub_sub_service
     ```
 
 ## Trademarks

--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ see more full featured examples in
 
 ## Running in a Container
 
-Below are the steps for running the service in a container. Note that the configuration files used
-by the containerized service are cloned from [.agemo/config](.agemo/config/) defined in the
-project's root.
+Below are the steps for running the service in a container. Note that the default configuration
+files used by the containerized service are cloned from [.agemo/config](.agemo/config/) defined in
+the project's root.
 
 ### Docker
 
@@ -243,6 +243,23 @@ command in the project root directory:
 
     ```shell
     docker stop pub_sub_service
+    ```
+
+#### Running in Docker with overrided configuration
+
+Follow the steps in [Running in Docker](#running-in-docker) to build the container.
+
+1. To run the container with overrided configuration, create your config files and set the path to
+the files to an environment variable called CONFIG_HOME:
+
+    ```shell
+    export CONFIG_HOME={path to directory containing config file}
+    ```
+
+1. Then run the container with the following command:
+
+    ```shell
+    docker -v ${CONFIG_HOME}:/mnt/config run --name pub_sub_service -p 50051:50051 --env-file=docker.env --add-host=host.docker.internal:host-gateway -it --rm pub_sub_service
     ```
 
 ### Podman

--- a/README.md
+++ b/README.md
@@ -245,11 +245,11 @@ command in the project root directory:
     docker stop pub_sub_service
     ```
 
-#### Running in Docker with overrided configuration
+#### Running in Docker with overriden configuration
 
 Follow the steps in [Running in Docker](#running-in-docker) to build the container.
 
-1. To run the container with overrided configuration, create your config file and set an
+1. To run the container with overriden configuration, create your config file and set an
 environment variable called CONFIG_HOME to the path to the config file:
 
     ```shell
@@ -302,11 +302,11 @@ root directory:
     podman ps -f ancestor=localhost/pub_sub_service:latest --format="{{.Names}}" | xargs podman stop
     ```
 
-#### Running in Podman with overrided configuration
+#### Running in Podman with overriden configuration
 
 Follow the steps in [Running in Podman](#running-in-podman) to build the container.
 
-1. To run the container with overrided configuration, create your config file and set an
+1. To run the container with overriden configuration, create your config file and set an
 environment variable called CONFIG_HOME to the path to the config file:
 
     ```shell

--- a/container_startup.sh
+++ b/container_startup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp -rn /mnt/config /sdv/.agemo
+
+/sdv/service

--- a/container_startup.sh
+++ b/container_startup.sh
@@ -4,6 +4,9 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
+# Exits immediately on failure.
+set -e
+
 # Copy any configuration files present to service configuration.
 cp -rn /mnt/config /sdv/.agemo
 

--- a/container_startup.sh
+++ b/container_startup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+# Copy any configuration files present to service configuration.
 cp -rn /mnt/config /sdv/.agemo
 
 /sdv/service


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows for an image created by the Dockerfile to be run with a configuration file that can be passed in when running the container.


## Description
<!--- Describe your changes in detail -->
This PR does the following:
- Adds a startup script used by the container to start the service. This script also copies any configuration passed into the container.
- Modified the Dockerfile to copy configuration from the mounted configuration directory to the service's configuration directory.
- Added how to run the container image with configuration at runtime for docker and podman
<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>[optional scope]: </description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
