### PR TITLE
Enable containerized build of integrated scenario

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,3 @@ target/
 devops/
 docs/
 tools/
-
-Cargo.lock

--- a/Dockerfile_integrated.amd64
+++ b/Dockerfile_integrated.amd64
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/engine/reference/builder/
+
+################################################################################
+# Create a stage for building the application.
+
+ARG RUST_VERSION=1.72.1
+ARG APP_NAME=pub-sub-service
+ARG UID=10001
+
+FROM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
+ARG APP_NAME
+WORKDIR /sdv
+
+COPY ./ .
+
+# Check that APP_NAME argument is valid.
+RUN /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${APP_NAME}" \
+    --regex "^[a-zA-Z_0-9-]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'APP_NAME'"; exit 1 )
+
+# Add Build dependencies.
+RUN apt update && apt upgrade -y && apt install -y \
+    cmake \
+    libssl-dev \
+    pkg-config \
+    protobuf-compiler
+
+# Build the application.
+RUN cargo build --release -p "${APP_NAME}"
+
+# Copy the built application to working directory.
+RUN cp ./target/release/"${APP_NAME}" /sdv/service
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the debian bullseye image as the foundation for running the app.
+# By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
+# most recent version of that tag when you build your Dockerfile. If
+# reproducability is important, consider using a digest
+# (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
+FROM docker.io/library/debian:bullseye-slim AS final
+ARG UID
+
+# Copy container scripts.
+COPY ./container/scripts/*.sh /sdv/scripts/
+
+# Check that UID argument is valid.
+RUN /sdv/scripts/argument_sanitizer.sh \
+    --arg-value "${UID}" \
+    --regex "^[0-9]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'UID'"; exit 1 )
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+
+# Create and add user ownership to config directory.
+RUN mkdir -p /sdv/.agemo/config
+RUN chown appuser /sdv/.agemo/config
+
+# Create mnt directory to copy override configs into.
+RUN mkdir -p /mnt/config
+
+USER appuser
+
+WORKDIR /sdv
+
+ENV AGEMO_HOME=/sdv/.agemo
+
+# Copy the executable from the "build" stage.
+COPY --from=build /sdv/service /sdv/
+
+# Copy the "integrated" config to the override config folder and rename it to what agemo expects
+COPY --from=build /sdv/config/pub_sub_service_settings.integrated.yaml /sdv/.agemo/config/pub_sub_service_settings.yaml
+
+# Expose the port that the application listens on.
+EXPOSE 50051
+
+# What the container should run when it is started.
+CMD ["/sdv/scripts/container_startup.sh"]

--- a/Dockerfile_integrated.amd64
+++ b/Dockerfile_integrated.amd64
@@ -93,7 +93,7 @@ COPY --from=build /sdv/service /sdv/
 # Copy the "integrated" config to the override config folder and rename it to what agemo expects
 COPY --from=build /sdv/config/pub_sub_service_settings.integrated.yaml /sdv/.agemo/config/pub_sub_service_settings.yaml
 
-# Expose the port that the application listens on.
+# Expose the port that the pub sub service listens on.
 EXPOSE 50051
 
 # What the container should run when it is started.

--- a/Dockerfile_integrated.arm64
+++ b/Dockerfile_integrated.arm64
@@ -96,7 +96,7 @@ COPY --from=build /sdv/service /sdv/
 # Copy the "integrated" config to the override config folder and rename it to what agemo expects
 COPY --from=build /sdv/config/pub_sub_service_settings.integrated.yaml /sdv/.agemo/config/pub_sub_service_settings.yaml
 
-# Expose the port that the application listens on.
+# Expose the port that the pub sub service listens on.
 EXPOSE 50051
 
 # What the container should run when it is started.

--- a/Dockerfile_integrated.arm64
+++ b/Dockerfile_integrated.arm64
@@ -1,0 +1,103 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/engine/reference/builder/
+
+################################################################################
+# Create a stage for building the application.
+
+ARG RUST_VERSION=1.72.1
+ARG APP_NAME=pub-sub-service
+ARG UID=10001
+
+FROM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
+ARG APP_NAME
+WORKDIR /sdv
+
+COPY ./ .
+
+# Check that APP_NAME argument is valid.
+RUN /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${APP_NAME}" \
+    --regex "^[a-zA-Z_0-9-]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'APP_NAME'"; exit 1 )
+
+# Add Build dependencies.
+RUN apt update && apt upgrade -y && apt install -y \
+    cmake \
+    libssl-dev \
+    pkg-config \
+    protobuf-compiler \
+    gcc-aarch64-linux-gnu
+
+RUN rustup target add aarch64-unknown-linux-gnu
+
+# Build the application.
+RUN cargo build --release --target=aarch64-unknown-linux-gnu -p "${APP_NAME}"
+
+# Copy the built application to working directory.
+RUN cp ./target/aarch64-unknown-linux-gnu/release/"${APP_NAME}" /sdv/service
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the debian bullseye image as the foundation for running the app.
+# By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
+# most recent version of that tag when you build your Dockerfile. If
+# reproducability is important, consider using a digest
+# (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
+FROM docker.io/arm64v8/debian:bullseye-slim AS final
+ARG UID
+
+# Copy container scripts.
+COPY ./container/scripts/*.sh /sdv/scripts/
+
+# Check that UID argument is valid.
+RUN /sdv/scripts/argument_sanitizer.sh \
+    --arg-value "${UID}" \
+    --regex "^[0-9]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'UID'"; exit 1 )
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+
+# Create and add user ownership to config directory.
+RUN mkdir -p /sdv/.agemo/config
+RUN chown appuser /sdv/.agemo/config
+
+# Create mnt directory to copy override configs into.
+RUN mkdir -p /mnt/config
+
+USER appuser
+
+WORKDIR /sdv
+
+ENV AGEMO_HOME=/sdv/.agemo
+
+# Copy the executable from the "build" stage.
+COPY --from=build /sdv/service /sdv/
+
+# Copy the "integrated" config to the override config folder and rename it to what agemo expects
+COPY --from=build /sdv/config/pub_sub_service_settings.integrated.yaml /sdv/.agemo/config/pub_sub_service_settings.yaml
+
+# Expose the port that the application listens on.
+EXPOSE 50051
+
+# What the container should run when it is started.
+CMD ["/sdv/scripts/container_startup.sh"]

--- a/config/pub_sub_service_settings.integrated.yaml
+++ b/config/pub_sub_service_settings.integrated.yaml
@@ -1,0 +1,29 @@
+###
+
+#
+# Pub Sub Service Settings
+#
+
+### Integrated Settings (i.e. using chariott's service discovery)
+
+# The URI that the Chariott Service Discovery listens on for requests.
+# Example: "http://0.0.0.0:50000"
+chariott_uri: "http://0.0.0.0:50000"
+
+# The namespace of the Pub Sub Service.
+# Example: "sdv.pubsub"
+namespace: "sdv.pubsub"
+
+# The name of the Pub Sub Service.
+# Example: "dynamic.pubsub"
+name: "dynamic.pubsub"
+
+# The IP address and port number that the Pub Sub Service listens on for requests.
+# Example: "0.0.0.0:50051"
+pub_sub_authority: "0.0.0.0:50051"
+
+# The URI of the messaging service used to facilitate publish and subscribe functionality.
+# Example: "mqtt://0.0.0.0:1883"
+messaging_uri: "mqtt://0.0.0.0:1883"
+
+###

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -13,6 +13,16 @@ document has instructions for building and running the provided Dockerfiles in
 x86-64 architecture.
 - [Dockerfile.arm64](../Dockerfile.arm64) - Dockerfile used to build the `Pub Sub Service` for the
 aarch64 architecture.
+- [Dockerfile_integrated.amd64](../Dockerfile_integrated.amd64) - Dockerfile used to build the
+`Pub Sub Service` using
+[Chariott Service Discovery](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)
+with the [integrated configuration](../config/pub_sub_service_settings.integrated.yaml) for the
+x86-64 architecture.
+- [Dockerfile_integrated.arm64](../Dockerfile_integrated.arm64) - Dockerfile used to build the
+`Pub Sub Service` using
+[Chariott Service Discovery](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)
+with the [integrated configuration](../config/pub_sub_service_settings.integrated.yaml) for the
+aarch64 architecture.
 
 #### Mosquitto MQTT Broker
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Closes #80 

## Motivation and Context
Today we have the configuration and Dockerfiles in order to build Agemo in standalone mode. Enable a containerized build of Agemo integrated with Chariott service discovery.
This also helps for building scenarios (like the Software Orchestration blueprint) which leverage Chariott and Agemo together.

## Description

- Add Dockerfile_integrated for both target architectures to containerize Agemo integrated with Chariott Service Discovery
- Add a configuration for "integrated" mode where Agemo uses Chariott Service Discovery
- Remove Cargo.lock from dockerignore. We don't have it in a gitignore, and it is recommended to include it to have deterministic builds.