### PR TITLE
Add multi-platform dockerfiles

### DIFF
--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -24,5 +24,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
-        npm install markdown-link-check
+        npm install markdown-link-check@3.11.2
         find . -type d \( -name node_modules -o -name .github \) -prune -o -type f -name '*.md' -print0 | xargs -0 -n1 node_modules/.bin/markdown-link-check --config ./tools/.markdownlinkcheck.jsonc --quiet

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -11,7 +11,7 @@
 ################################################################################
 # Create a stage for building the application.
 
-ARG RUST_VERSION=1.72.1
+ARG RUST_VERSION=1.74
 ARG APP_NAME=pub-sub-service
 ARG UID=10001
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,7 +11,7 @@
 ################################################################################
 # Create a stage for building the application.
 
-ARG RUST_VERSION=1.72.1
+ARG RUST_VERSION=1.74
 ARG APP_NAME=pub-sub-service
 ARG UID=10001
 

--- a/Dockerfile.mosquitto.multi
+++ b/Dockerfile.mosquitto.multi
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/engine/reference/builder/
+
+################################################################################
+# Create a stage for building the application.
+
+FROM --platform=$TARGETPLATFORM docker.io/library/eclipse-mosquitto
+WORKDIR /mosquitto/config
+
+COPY ./pub-sub-service/src/connectors/mosquitto.conf ./mosquitto.conf
+
+# Expose the port that the mqtt broker listens on.
+EXPOSE 1883

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -12,10 +12,14 @@
 # Create a stage for building the application.
 
 ARG RUST_VERSION=1.74
-ARG APP_NAME=simple-publisher
+ARG APP_NAME=pub-sub-service
 ARG UID=10001
 
-FROM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:${RUST_VERSION} AS build
+
+# Target architecture to cross-compile
+ARG TARGETARCH
+
 ARG APP_NAME
 WORKDIR /sdv
 
@@ -27,21 +31,32 @@ RUN /sdv/container/scripts/argument_sanitizer.sh \
     --regex "^[a-zA-Z_0-9-]+$" || \
     ( echo "Argument sanitizer failed for ARG 'APP_NAME'"; exit 1 )
 
+# Check that TARGETARCH argument is valid.
+RUN /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${TARGETARCH}" \
+    --regex "^[a-zA-Z_0-9-]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'TARGETARCH'"; exit 1 )
+
 # Add Build dependencies.
 RUN apt update && apt upgrade -y && apt install -y \
     cmake \
     libssl-dev \
     pkg-config \
-    protobuf-compiler \
-    gcc-aarch64-linux-gnu
+    protobuf-compiler
 
-RUN rustup target add aarch64-unknown-linux-gnu
-
-# Build the application.
-RUN cargo build --release --target=aarch64-unknown-linux-gnu -p "${APP_NAME}"
-
-# Copy the built application to working directory.
-RUN cp ./target/aarch64-unknown-linux-gnu/release/"${APP_NAME}" /sdv/service
+# Based on the target architecture, add the appropriate build target and build service.
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        CARGOARCH="x86_64-unknown-linux-gnu"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        apt install -y gcc-aarch64-linux-gnu; \
+        CARGOARCH="aarch64-unknown-linux-gnu"; \
+    else \
+        echo "Unsupported cross-compile architecture"; \
+        exit 1; \
+    fi; \
+        rustup target add ${CARGOARCH}; \
+        cargo build --release --target=${CARGOARCH} -p "${APP_NAME}"; \
+        cp /sdv/target/${CARGOARCH}/release/"${APP_NAME}" /sdv/service
 
 ################################################################################
 # Create a new stage for running the application that contains the minimal
@@ -54,7 +69,7 @@ RUN cp ./target/aarch64-unknown-linux-gnu/release/"${APP_NAME}" /sdv/service
 # most recent version of that tag when you build your Dockerfile. If
 # reproducability is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
-FROM docker.io/arm64v8/debian:bullseye-slim AS final
+FROM --platform=$TARGETPLATFORM docker.io/library/debian:bullseye-slim AS final
 ARG UID
 
 # Copy container scripts.
@@ -88,13 +103,13 @@ USER appuser
 
 WORKDIR /sdv
 
-ENV AGEMO_SAMPLES_HOME=/sdv/.agemo
+ENV AGEMO_HOME=/sdv/.agemo
 
 # Copy the executable from the "build" stage.
 COPY --from=build /sdv/service /sdv/
 
-# Copy default configs.
-COPY --from=build /sdv/.agemo-samples/config/ /sdv/.agemo/config/
+# Expose the port that the application listens on.
+EXPOSE 50051
 
 # What the container should run when it is started.
 CMD ["/sdv/scripts/container_startup.sh"]

--- a/Dockerfile.samples.amd64
+++ b/Dockerfile.samples.amd64
@@ -11,7 +11,7 @@
 ################################################################################
 # Create a stage for building the application.
 
-ARG RUST_VERSION=1.72.1
+ARG RUST_VERSION=1.74
 ARG APP_NAME=simple-publisher
 ARG UID=10001
 

--- a/Dockerfile_integrated.amd64
+++ b/Dockerfile_integrated.amd64
@@ -11,7 +11,7 @@
 ################################################################################
 # Create a stage for building the application.
 
-ARG RUST_VERSION=1.72.1
+ARG RUST_VERSION=1.74
 ARG APP_NAME=pub-sub-service
 ARG UID=10001
 

--- a/Dockerfile_integrated.arm64
+++ b/Dockerfile_integrated.arm64
@@ -11,7 +11,7 @@
 ################################################################################
 # Create a stage for building the application.
 
-ARG RUST_VERSION=1.72.1
+ARG RUST_VERSION=1.74
 ARG APP_NAME=pub-sub-service
 ARG UID=10001
 

--- a/Dockerfile_integrated.multi
+++ b/Dockerfile_integrated.multi
@@ -12,10 +12,14 @@
 # Create a stage for building the application.
 
 ARG RUST_VERSION=1.74
-ARG APP_NAME=simple-publisher
+ARG APP_NAME=pub-sub-service
 ARG UID=10001
 
-FROM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:${RUST_VERSION} AS build
+
+# Target architecture to cross-compile
+ARG TARGETARCH
+
 ARG APP_NAME
 WORKDIR /sdv
 
@@ -27,21 +31,32 @@ RUN /sdv/container/scripts/argument_sanitizer.sh \
     --regex "^[a-zA-Z_0-9-]+$" || \
     ( echo "Argument sanitizer failed for ARG 'APP_NAME'"; exit 1 )
 
+# Check that TARGETARCH argument is valid.
+RUN /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${TARGETARCH}" \
+    --regex "^[a-zA-Z_0-9-]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'TARGETARCH'"; exit 1 )
+
 # Add Build dependencies.
 RUN apt update && apt upgrade -y && apt install -y \
     cmake \
     libssl-dev \
     pkg-config \
-    protobuf-compiler \
-    gcc-aarch64-linux-gnu
+    protobuf-compiler
 
-RUN rustup target add aarch64-unknown-linux-gnu
-
-# Build the application.
-RUN cargo build --release --target=aarch64-unknown-linux-gnu -p "${APP_NAME}"
-
-# Copy the built application to working directory.
-RUN cp ./target/aarch64-unknown-linux-gnu/release/"${APP_NAME}" /sdv/service
+# Based on the target architecture, add the appropriate build target and build service.
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        CARGOARCH="x86_64-unknown-linux-gnu"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        apt install -y gcc-aarch64-linux-gnu; \
+        CARGOARCH="aarch64-unknown-linux-gnu"; \
+    else \
+        echo "Unsupported cross-compile architecture"; \
+        exit 1; \
+    fi; \
+        rustup target add ${CARGOARCH}; \
+        cargo build --release --target=${CARGOARCH} -p "${APP_NAME}"; \
+        cp /sdv/target/${CARGOARCH}/release/"${APP_NAME}" /sdv/service
 
 ################################################################################
 # Create a new stage for running the application that contains the minimal
@@ -54,7 +69,7 @@ RUN cp ./target/aarch64-unknown-linux-gnu/release/"${APP_NAME}" /sdv/service
 # most recent version of that tag when you build your Dockerfile. If
 # reproducability is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
-FROM docker.io/arm64v8/debian:bullseye-slim AS final
+FROM --platform=$TARGETPLATFORM docker.io/library/debian:bullseye-slim AS final
 ARG UID
 
 # Copy container scripts.
@@ -88,13 +103,16 @@ USER appuser
 
 WORKDIR /sdv
 
-ENV AGEMO_SAMPLES_HOME=/sdv/.agemo
+ENV AGEMO_HOME=/sdv/.agemo
 
 # Copy the executable from the "build" stage.
 COPY --from=build /sdv/service /sdv/
 
-# Copy default configs.
-COPY --from=build /sdv/.agemo-samples/config/ /sdv/.agemo/config/
+# Copy the "integrated" config to the override config folder and rename it to what agemo expects
+COPY --from=build /sdv/config/pub_sub_service_settings.integrated.yaml /sdv/.agemo/config/pub_sub_service_settings.yaml
+
+# Expose the port that the application listens on.
+EXPOSE 50051
 
 # What the container should run when it is started.
 CMD ["/sdv/scripts/container_startup.sh"]

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -13,7 +13,7 @@ document has instructions for building and running the provided Dockerfiles in
 x86-64 architecture.
 - [Dockerfile.arm64](../Dockerfile.arm64) - Dockerfile used to build the `Pub Sub Service` for the
 aarch64 architecture.
-- [Dockerfile.multi](../Dockerfile.arm64) - Dockerfile used to build the `Pub Sub Service` for
+- [Dockerfile.multi](../Dockerfile.multi) - Dockerfile used to build the `Pub Sub Service` for
 multiple architectures based on the TARGETARCH argument.
 - [Dockerfile_integrated.amd64](../Dockerfile_integrated.amd64) - Dockerfile used to build the
 `Pub Sub Service` using
@@ -25,7 +25,7 @@ x86-64 architecture.
 [Chariott Service Discovery](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)
 with the [integrated configuration](../config/pub_sub_service_settings.integrated.yaml) for the
 aarch64 architecture.
-- [Dockerfile_integrated.multi](../Dockerfile_integrated.arm64) - Dockerfile used to build the
+- [Dockerfile_integrated.multi](../Dockerfile_integrated.multi) - Dockerfile used to build the
 `Pub Sub Service` using
 [Chariott Service Discovery](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)
 with the [integrated configuration](../config/pub_sub_service_settings.integrated.yaml) for
@@ -37,7 +37,7 @@ multiple architectures based on the TARGETARCH argument.
 `Mosquitto MQTT Broker` with the appropriate configuration for the x86-64 architecture.
 - [Dockerfile.mosquitto.arm64](../Dockerfile.mosquitto.arm64) - Dockerfile used to build the
 `Mosquitto MQTT Broker` with the appropriate configuration for the aarch64 architecture.
-- [Dockerfile.mosquitto.multi](../Dockerfile.mosquitto.arm64) - Dockerfile used to build the
+- [Dockerfile.mosquitto.multi](../Dockerfile.mosquitto.multi) - Dockerfile used to build the
 `Mosquitto MQTT Broker` with the appropriate configuration for multiple architectures based on the
 TARGETARCH argument.
 

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -13,6 +13,8 @@ document has instructions for building and running the provided Dockerfiles in
 x86-64 architecture.
 - [Dockerfile.arm64](../Dockerfile.arm64) - Dockerfile used to build the `Pub Sub Service` for the
 aarch64 architecture.
+- [Dockerfile.multi](../Dockerfile.arm64) - Dockerfile used to build the `Pub Sub Service` for
+multiple architectures based on the TARGETARCH argument.
 - [Dockerfile_integrated.amd64](../Dockerfile_integrated.amd64) - Dockerfile used to build the
 `Pub Sub Service` using
 [Chariott Service Discovery](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)
@@ -23,6 +25,11 @@ x86-64 architecture.
 [Chariott Service Discovery](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)
 with the [integrated configuration](../config/pub_sub_service_settings.integrated.yaml) for the
 aarch64 architecture.
+- [Dockerfile_integrated.multi](../Dockerfile_integrated.arm64) - Dockerfile used to build the
+`Pub Sub Service` using
+[Chariott Service Discovery](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)
+with the [integrated configuration](../config/pub_sub_service_settings.integrated.yaml) for
+multiple architectures based on the TARGETARCH argument.
 
 #### Mosquitto MQTT Broker
 
@@ -30,6 +37,9 @@ aarch64 architecture.
 `Mosquitto MQTT Broker` with the appropriate configuration for the x86-64 architecture.
 - [Dockerfile.mosquitto.arm64](../Dockerfile.mosquitto.arm64) - Dockerfile used to build the
 `Mosquitto MQTT Broker` with the appropriate configuration for the aarch64 architecture.
+- [Dockerfile.mosquitto.multi](../Dockerfile.mosquitto.arm64) - Dockerfile used to build the
+`Mosquitto MQTT Broker` with the appropriate configuration for multiple architectures based on the
+TARGETARCH argument.
 
 #### Sample Applications
 
@@ -72,6 +82,17 @@ Dockerfile:
 
     >Note: The build arg `APP_NAME` needs to be passed in for all sample applications to build the
     correct sample.
+
+    Or to build a multi-platform image for `pub-sub-service` project and push it to a container
+    registry:
+    You must first create a new builder using the docker-container driver, which gives you access
+    to more complex features like multi-platform build. See more information here:
+    [multi-platform builds.](https://docs.docker.com/build/building/multi-platform/#cross-compilation)
+
+    ```shell
+    docker buildx create --name multibuilder --driver docker-container --use
+    docker buildx build --platform=linux/amd64,linux/arm64 -f Dockerfile.multi -t <container_registry>/pub_sub_service_multi --push .
+    ```
 
 1. Once the container has been built, start the container in interactive mode with the following
 command in the project root directory:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adds multiplatform dockerfiles, allowing for a simpler build process for the blueprints.


## Description
<!--- Describe your changes in detail -->
- Add multiplatform dockerfiles for pub-sub-service, mosquitto, and integrated pub-sub-service
- Updated documentation
- Updated all dockerfiles to point to rust 1.74 which is the new toolchain version
<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>[optional scope]: </description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
